### PR TITLE
#47 : Add "no-op" and "hilo" optimizers for sequences

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -13,5 +13,13 @@
       <entry name="!?*.aj" />
       <entry name="!?*.ceylon" />
     </wildcardResourcePatterns>
+    <bytecodeTargetLevel>
+      <module name="hibernate-rx.example.main" target="1.8" />
+      <module name="hibernate-rx.example.test" target="1.8" />
+      <module name="hibernate-rx.hibernate-rx-api.main" target="1.8" />
+      <module name="hibernate-rx.hibernate-rx-api.test" target="1.8" />
+      <module name="hibernate-rx.hibernate-rx-core.main" target="1.8" />
+      <module name="hibernate-rx.hibernate-rx-core.test" target="1.8" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,11 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="disableWrapperSourceDistributionNotification" value="true" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="/usr/local/Cellar/gradle/6.0.1/libexec" />
-        <option name="gradleJvm" value="1.8" />
+        <option name="gradleHome" value="$USER_HOME$/apps/gradle-2.2.1" />
+        <option name="gradleJvm" value="1.8 (1)" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -17,7 +16,6 @@
             <option value="$PROJECT_DIR$/hibernate-rx-core" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/hibernate-rx.iml
+++ b/.idea/hibernate-rx.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="OptionalUsedAsFieldOrParameterType" enabled="false" level="WARNING" enabled_by_default="false" />
-  </profile>
-</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" assert-keyword="true" jdk-15="true" project-jdk-name="1.8.0_172" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ installed on your machine.
 
 ### Obtaining a snapshot build of Hibernate ORM
 
-Temporarily, you'll need a snapshot build of `hibernate-core-5.4.11.jar`.
+Temporarily, you'll need a snapshot build of `hibernate-core-5.4.12.jar`.
 Clone the [hibernate-orm][] project from GitHub, and run:
 
     ./gradlew hibernate-core:publishToMavenLocal
@@ -71,7 +71,7 @@ The project has been tested with:
 - Java 8
 - PostgreSQL 12
 - MySQL 8
-- [Hibernate ORM](https://hibernate.org/orm/) 5.4.11-SNAPSHOT
+- [Hibernate ORM](https://hibernate.org/orm/) 5.4.12-SNAPSHOT
 - [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 0.0.12
 - [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 0.0.12
 

--- a/hibernate-rx-api/build.gradle
+++ b/hibernate-rx-api/build.gradle
@@ -7,7 +7,7 @@ description = 'Hibernate RX API'
  
 dependencies {
     implementation 'org.reactivestreams:reactive-streams:1.0.2'
-    implementation 'org.hibernate:hibernate-core:5.4.11-SNAPSHOT'
+    implementation 'org.hibernate:hibernate-core:5.4.12-SNAPSHOT'
 
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'io.vertx:vertx-junit5:3.6.2'

--- a/hibernate-rx-core/build.gradle
+++ b/hibernate-rx-core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     compile project(':hibernate-rx-api')
 
-    compile ('org.hibernate:hibernate-core:5.4.11-SNAPSHOT') {
+    compile ('org.hibernate:hibernate-core:5.4.12-SNAPSHOT') {
         exclude group: 'org.javassist', module: 'javassist'
         exclude group: 'net.bytebuddy', module: 'byte-buddy'
         exclude group: 'org.dom4j', module: 'dom4j'
@@ -19,7 +19,7 @@ dependencies {
         exclude group: 'org.hibernate.common', module: 'hibernate-commons-annotations'
         exclude group: 'org.jboss.spec.javax.transaction', module: 'jboss-transaction-api_1.2_spec'
     }
-    testCompile ('org.hibernate:hibernate-testing:5.4.11-SNAPSHOT')
+    testCompile ('org.hibernate:hibernate-testing:5.4.12-SNAPSHOT')
     compile 'io.smallrye.reactive:smallrye-axle-pg-client:0.0.12'
     compile 'io.smallrye.reactive:smallrye-axle-mysql-client:0.0.12'
 

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/HiLoRxOptimizer.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/HiLoRxOptimizer.java
@@ -1,0 +1,56 @@
+package org.hibernate.rx.persister.entity.impl;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.id.IdentifierGeneratorHelper;
+import org.hibernate.id.enhanced.HiLoOptimizer;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class HiLoRxOptimizer extends HiLoOptimizer implements RxOptimizer<Long> {
+
+	public HiLoRxOptimizer(Class<?> integerType, int incrementSize) {
+		super( integerType, incrementSize );
+	}
+
+	@Override
+	public synchronized CompletionStage<Optional<Long>> generate(RxAccessCallback callback) {
+
+		final GenerationState generationState = locateGenerationState( callback.getTenantIdentifier() );
+
+		if ( !generationState.isInitialized() ) {
+			return getValidFirstValueFromDatabase( callback )
+					.thenCompose( validFirstValue -> getActualNextValue( generationState, validFirstValue ) );
+		}
+		else if ( generationState.requiresNewSourceValue() ) {
+			return callback.getNextValue()
+					.thenCompose( valueFromDatabase -> getActualNextValue( generationState, valueFromDatabase ) );
+		}
+		else {
+			return CompletableFuture.completedFuture(Optional.of(generationState.makeValueThenIncrement().longValue()));
+		}
+	}
+
+	private CompletionStage<Optional<Long>> getValidFirstValueFromDatabase(RxAccessCallback callback) {
+		// TODO: increment if it is < 1
+		// while ( generationState.lastSourceValue.lt( 1 ) ) {
+		//	generationState.lastSourceValue = callback.getNextValue();
+		//}
+
+		return callback.getNextValue();
+	}
+
+	private CompletionStage<Optional<Long>> getActualNextValue(GenerationState generationState, Optional<Long> valueFromDataBase) {
+
+		if (!valueFromDataBase.isPresent()) {
+			throw new AssertionFailure("No sequence value present!");
+		}
+
+		generationState.updateFromNewSourceValue(
+				IdentifierGeneratorHelper.getIntegralDataTypeHolder( Long.class ).initialize( valueFromDataBase.get() )
+		);
+
+		return CompletableFuture.completedFuture( Optional.of(generationState.makeValueThenIncrement().longValue()));
+	}
+}

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/NoopRxOptimizer.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/NoopRxOptimizer.java
@@ -1,0 +1,19 @@
+package org.hibernate.rx.persister.entity.impl;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.id.IdentifierGeneratorHelper;
+import org.hibernate.id.IntegralDataTypeHolder;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NoopRxOptimizer implements RxOptimizer<Long> {
+
+	@Override
+	public synchronized CompletionStage<Optional<Long>> generate(RxAccessCallback callback) {
+		return callback.getNextValue();
+	}
+}

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAccessCallback.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAccessCallback.java
@@ -1,0 +1,21 @@
+package org.hibernate.rx.persister.entity.impl;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+public interface RxAccessCallback {
+	/**
+	 * Retrieve the next value from the underlying source.
+	 *
+	 * @return The next value.
+	 */
+	CompletionStage<Optional<Long>> getNextValue();
+
+	/**
+	 * Obtain the tenant identifier (multi-tenancy), if one, associated with this callback.
+	 *
+	 * @return The tenant identifier
+	 */
+	String getTenantIdentifier();
+}
+

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxOptimizer.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxOptimizer.java
@@ -1,0 +1,8 @@
+package org.hibernate.rx.persister.entity.impl;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+public interface RxOptimizer<T> {
+	CompletionStage<Optional<T>> generate(RxAccessCallback callback);
+}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/SequenceGeneratorTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/SequenceGeneratorTest.java
@@ -1,17 +1,26 @@
 package org.hibernate.rx;
 
 import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.id.enhanced.StandardOptimizerDescriptor;
 import org.junit.Test;
 
 import javax.persistence.*;
 import java.util.Objects;
 
+/**
+ * Tests a sequence using the "no-op" optimizer.
+ */
 public class SequenceGeneratorTest extends BaseRxTest {
 
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
+		configuration.setProperty(
+				AvailableSettings.PREFERRED_POOLED_OPTIMIZER,
+				StandardOptimizerDescriptor.NONE.getExternalName()
+		);
 		configuration.addAnnotatedClass( SequenceId.class );
 		return configuration;
 	}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/SequenceHiLoGeneratorTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/SequenceHiLoGeneratorTest.java
@@ -1,0 +1,162 @@
+package org.hibernate.rx;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.id.enhanced.StandardOptimizerDescriptor;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Tests a sequence using the "hilo" optimizer.
+ */
+public class SequenceHiLoGeneratorTest extends BaseRxTest {
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.setProperty(
+				AvailableSettings.PREFERRED_POOLED_OPTIMIZER,
+				StandardOptimizerDescriptor.HILO.getExternalName()
+		);
+		configuration.setProperty(
+				AvailableSettings.GENERATE_STATISTICS,
+				"true"
+		);
+		configuration.addAnnotatedClass(SequenceId.class);
+		return configuration;
+	}
+
+	@Test
+	public void testSequenceGenerator(TestContext context) {
+
+		CompletionStage<RxSession> sessionStage = openSession();
+
+		for (int i = 0; i < 7; i++) {
+			SequenceId sequenceId = new SequenceId();
+			// set sequenceId.string so the integer suffix is the same as its id
+			sequenceId.string = "Hello World" + (i + 4);
+			sessionStage = sessionStage.thenCompose(s -> s.persist(sequenceId));
+		}
+
+		sessionStage = sessionStage.thenCompose(s -> s.flush())
+				.thenCompose(v -> openSession());
+
+		for (int i = 0; i < 7; i++) {
+			final int id = i + 4;
+			sessionStage = sessionStage.thenCompose(s2 ->
+					findAndCheck(s2, context, id, id, 0 )
+			);
+			sessionStage = sessionStage.thenCompose(s2 ->
+					findAndCheck(s2, context, id, id, 0 )
+			);
+			sessionStage = sessionStage.thenCompose(s2 ->
+					findCheckIncrementString(s2, context, id, id, id + 1,  0 )
+			);
+		}
+
+		sessionStage = sessionStage.thenCompose(s -> s.flush());
+		for (int i = 0; i < 7; i++) {
+			final int id = i + 4;
+			sessionStage = sessionStage.thenCompose(s2 ->
+					findAndCheck(s2, context, id, id + 1, 1 )
+			);
+		}
+
+		sessionStage = sessionStage.thenCompose(s3 -> openSession()  );
+
+		for (int i = 0; i < 7; i++) {
+			final int id = i + 4;
+			sessionStage = sessionStage.thenCompose(s3 ->
+					findAndCheck(s3, context, id, id + 1, 1 )
+			);
+		}
+
+		test( context, sessionStage );
+	}
+
+	private CompletionStage<RxSession> findAndCheck(RxSession s, TestContext context, int id, int stringSuffix, int version) {
+		return s.find(SequenceId.class, id)
+				.thenAccept(bt -> {
+					context.assertTrue(bt.isPresent());
+					SequenceId bb = bt.get();
+					context.assertEquals(bb.id, id);
+					context.assertEquals(bb.string, "Hello World" + stringSuffix);
+					context.assertEquals(bb.version, version);
+				}).thenApply( v-> s );
+	}
+
+	private CompletionStage<RxSession> findCheckIncrementString(RxSession s, TestContext context, int id, int stringSuffixOld, int stringSuffixNew, int version) {
+		return s.find(SequenceId.class, id)
+				.thenAccept(bt -> {
+					context.assertTrue(bt.isPresent());
+					SequenceId bb = bt.get();
+					context.assertEquals(bb.id, id);
+					context.assertEquals(bb.string, "Hello World" + stringSuffixOld);
+					context.assertEquals(bb.version, version);
+					bb.string = "Hello World" + (stringSuffixNew);
+				}).thenApply(v -> s);
+	}
+
+	@Entity(name = "SequenceId")
+	@SequenceGenerator(name = "seq",
+			sequenceName = "test_hilo_id_seq",
+			initialValue = 2,
+			allocationSize = 3
+	)
+	public static class SequenceId {
+		@Id @GeneratedValue(generator = "seq")
+		Integer id;
+		@Version Integer version;
+		String string;
+
+		public SequenceId() {
+		}
+
+		public SequenceId(Integer id, String string) {
+			this.id = id;
+			this.string = string;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public void setString(String string) {
+			this.string = string;
+		}
+
+		@Override
+		public String toString() {
+			return id + ": " + string;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			SequenceId sequenceId = (SequenceId) o;
+			return Objects.equals(string, sequenceId.string);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(string);
+		}
+	}
+}


### PR DESCRIPTION
Here is my attempt at adding support for "no-op" and "hilo" optimizers used with a sequence for https://github.com/hibernate/hibernate-rx/issues/47 .

This fix relies on the following change to hibernate-orm:
https://github.com/gbadner/hibernate-core/commit/fc9afeb0e816b0bca50825f8a54495b396e0b141

I hesitate to create an HHH jira with the above commit until the code in this PR is at least sanity-checked.

Also, this fix updates the hibernate-orm dependencies to 5.4.12-SNAPSHOT.

Please be kind.