### PR TITLE
Extract the Hibernate ORM version into a build parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,15 @@ subprojects {
     }
 }
 
+// Versions which need to be aligned across modules;
+// this also allows to override the build from a parameter,
+// which can be useful to monitor compatibility for upcoming versions on CI:
+// ./gradlew clean build -PhibernateOrmVersion=5.4.9-SNAPSHOT
+ext {
+    hibernateOrmVersion = '5.4.12.Final'
+}
+
+
 //allprojects {
 //    apply plugin: 'checkstyle'
 //

--- a/hibernate-rx-api/build.gradle
+++ b/hibernate-rx-api/build.gradle
@@ -7,7 +7,7 @@ description = 'Hibernate RX API'
  
 dependencies {
     implementation 'org.reactivestreams:reactive-streams:1.0.2'
-    implementation 'org.hibernate:hibernate-core:5.4.11-SNAPSHOT'
+    implementation "org.hibernate:hibernate-core:${hibernateOrmVersion}"
 
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'io.vertx:vertx-junit5:3.6.2'

--- a/hibernate-rx-core/build.gradle
+++ b/hibernate-rx-core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     compile project(':hibernate-rx-api')
 
-    compile ('org.hibernate:hibernate-core:5.4.11-SNAPSHOT') {
+    compile ("org.hibernate:hibernate-core:${hibernateOrmVersion}") {
         exclude group: 'org.javassist', module: 'javassist'
         exclude group: 'net.bytebuddy', module: 'byte-buddy'
         exclude group: 'org.dom4j', module: 'dom4j'
@@ -19,7 +19,7 @@ dependencies {
         exclude group: 'org.hibernate.common', module: 'hibernate-commons-annotations'
         exclude group: 'org.jboss.spec.javax.transaction', module: 'jboss-transaction-api_1.2_spec'
     }
-    testCompile ('org.hibernate:hibernate-testing:5.4.11-SNAPSHOT')
+    testCompile ("org.hibernate:hibernate-testing:${hibernateOrmVersion}")
     compile 'io.smallrye.reactive:smallrye-axle-pg-client:0.0.12'
     compile 'io.smallrye.reactive:smallrye-axle-mysql-client:0.0.12'
 


### PR DESCRIPTION
For two reasons:
 1- ensure the versions are aligned among components (e.g. same version of `hibernate-core` as `hibernate-testing`
 2- allows to easily check compatibility with a different version

In particular, I'm thinking to setup a CI job which will monitor both existing ORM tags and next upcoming snapshots. 

    ./gradlew clean build -PhibernateOrmVersion=5.4.13-SNAPSHOT

That's not to say we need to strive to have master pass with multiple versions of ORM, but to be aware and informed: we can then decide ad-hoc.


