### PR TITLE
fix problem in cascade persist

### DIFF
--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/CascadeTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/CascadeTest.java
@@ -44,7 +44,7 @@ public class CascadeTest extends BaseRxTest {
 							Node node = option.get();
 							context.assertTrue( node.loaded );
 							context.assertEquals( node.string, basik.string);
-							context.assertEquals( node.version, 1 );
+							context.assertEquals( node.version, 0 );
 
 							node.string = "Adopted";
 							node.parent = new Node("New Parent");
@@ -54,7 +54,7 @@ public class CascadeTest extends BaseRxTest {
 										context.assertTrue( node.postUpdated && node.preUpdated );
 										context.assertFalse( node.postPersisted && node.prePersisted );
 										context.assertTrue( node.parent.postPersisted && node.parent.prePersisted );
-										context.assertEquals( node.version, 2 );
+										context.assertEquals( node.version, 1 );
 									});
 						}))
 						.thenCompose(v -> openSession())
@@ -63,7 +63,7 @@ public class CascadeTest extends BaseRxTest {
 										.thenCompose( option -> {
 											context.assertTrue( option.isPresent() );
 											Node node = option.get();
-											context.assertEquals( node.version, 2 );
+											context.assertEquals( node.version, 1 );
 											context.assertEquals( node.string, "Adopted");
 											return s2.fetch( node.parent )
 													.thenCompose( opt -> {
@@ -84,7 +84,7 @@ public class CascadeTest extends BaseRxTest {
 							Node node = option.get();
 							context.assertFalse( node.postUpdated && node.preUpdated );
 							context.assertFalse( node.postPersisted && node.prePersisted );
-							context.assertEquals( node.version, 2 );
+							context.assertEquals( node.version, 1 );
 							context.assertEquals( node.string, "ADOPTED");
 							basik.version = node.version;
 							basik.string = "Hello World!";


### PR DESCRIPTION
As reported by @gbadner [here](https://github.com/hibernate/hibernate-rx/pull/66#issuecomment-592692186), the way I implemented cascading operations wasn't quite perfect for cascade persist.

When we cascade the persist operation from a child to a parent, we should wait until the parent persist operation has completed *and its id has been generated* before capturing the snapshot of the child, because we're going to need the parent id as a foreign key.

This commit fixes that. However, I don't totally love this solution since it means cascade persist functions a bit differently from other cascading operations.

An alternative fix would be to cascade the persist operation in two phases, where the first phase only generates and assigns ids. But that's more work.

I need to think about this further.