### PR TITLE
65 Fix master build

### DIFF
--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
@@ -216,7 +216,7 @@ public class DefaultRxLoadEventListener implements LoadEventListener, RxLoadEven
 		return entityCs.thenApply( optional -> {
 			boolean isOptionalInstance = event.getInstanceToLoad() != null;
 
-			if ( optional.isPresent() && ( !options.isAllowNulls() || isOptionalInstance ) ) {
+			if ( !optional.isPresent() && ( !options.isAllowNulls() || isOptionalInstance ) ) {
 				session
 						.getFactory()
 						.getEntityNotFoundDelegate()

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
@@ -27,6 +27,7 @@ import org.hibernate.type.Type;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 
 /**
  * A reactific {@link org.hibernate.event.internal.DefaultLoadEventListener}.
@@ -43,7 +44,17 @@ public class DefaultRxLoadEventListener implements LoadEventListener, RxLoadEven
 	public void onLoad(
 			final LoadEvent event,
 			final LoadEventListener.LoadType loadType) throws HibernateException {
-		throw new UnsupportedOperationException();
+		try {
+			rxOnLoad( event, loadType ).toCompletableFuture().get();
+			Object result = event.getResult();
+			if ( result instanceof Optional) {
+				Optional optResult = (Optional) event.getResult();
+				event.setResult( optResult.orElse(  null ) );
+			}
+		}
+		catch (Exception e) {
+			throw new HibernateException( e );
+		}
 	}
 
 	/**

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
@@ -116,6 +116,7 @@ public class DefaultRxLoadEventListener implements LoadEventListener, RxLoadEven
 					if ( x instanceof HibernateException ) {
 						LOG.unableToLoadCommand( (HibernateException) x );
 					}
+					RxUtil.rethrowIfNotNull( x );
 				} );
 	}
 

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/RxSessionInternalImpl.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/RxSessionInternalImpl.java
@@ -3,6 +3,7 @@ package org.hibernate.rx.impl;
 import org.hibernate.*;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.internal.StatefulPersistenceContext;
+import org.hibernate.engine.spi.EffectiveEntityGraph;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.internal.MergeContext;
 import org.hibernate.event.service.spi.EventListenerRegistry;
@@ -10,6 +11,8 @@ import org.hibernate.event.spi.*;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.RootGraph;
 import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.internal.EntityManagerMessageLogger;
+import org.hibernate.internal.HEMLogging;
 import org.hibernate.internal.SessionCreationOptions;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.internal.SessionImpl;
@@ -44,6 +47,7 @@ import java.util.function.Supplier;
  * Hibernate core compares the identity of session instances.
  */
 public class RxSessionInternalImpl extends SessionImpl implements RxSessionInternal, EventSource {
+	private static final EntityManagerMessageLogger log = HEMLogging.messageLogger( RxSessionInternalImpl.class );
 
 	private transient RxActionQueue rxActionQueue = new RxActionQueue( this );
 
@@ -143,6 +147,13 @@ public class RxSessionInternalImpl extends SessionImpl implements RxSessionInter
 					}
 					return v;
 				});
+	}
+
+	private Boolean getReadOnlyFromLoadQueryInfluencers() {
+		if ( getLoadQueryInfluencers() != null ) {
+			return getLoadQueryInfluencers().getReadOnly();
+		}
+		return null;
 	}
 
 	@Override

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/util/impl/RxUtil.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/util/impl/RxUtil.java
@@ -40,4 +40,9 @@ public class RxUtil {
 		throw (T) x;
 	}
 
+	public static <T extends Throwable, Ret> void rethrowIfNotNull(Throwable x) throws T {
+		if (x != null ) {
+			throw (T) x;
+		}
+	}
 }


### PR DESCRIPTION
I left commit https://github.com/hibernate/hibernate-rx/commit/cc126844ee9d5c1b75e38826a651b9f0a11d8e30 to show what's the piece of code causing issues. But it requires the use of a blocking method.

The final fix is more complicated but I think it highlights better what's going on.

This patch is simpler than  https://github.com/hibernate/hibernate-rx/pull/66 and doesn't require the ORM dependency update.

The assumption I'm making here is that we only return a CompletionStage when we load the entity from the datasource and in all the other cases we return a proxy.

I removed the comment about checkIdClass because I think it was a mistake the way we implemented it. I will create an issue to make sure that we test that use case.

