### PR TITLE
Add Testcontainers and CI Pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+sudo: required
+services:
+  - docker
+cache:
+  directories:
+    - $HOME/.m2
+before_cache:
+  - rm -rf $HOME/.m2/repository/io/hibernate/rx
+jobs:
+  include:
+    - stage: test
+      name: "Run tests"
+      jdk: openjdk8
+      script: ./gradlew test -Pdocker

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ To publish Hibernate RX to your local Maven repository, run:
 
 ### Running tests
 
+Tests require an instance of the corresponding database to be running on your machine.
+You can start the database instances in any way you like:
+
+#### Starting bare-metal databases 
+
 To run the tests, ensure that PostgreSQL is installed on your machine.
 From the command line, type the following commands:
 
@@ -61,12 +66,26 @@ and then type the following:
     create database `hibernate-rx`;
     create user `hibernate-rx` identified by 'hibernate-rx';
     grant all on `hibernate-rx`.* to `hibernate-rx`;
+    
+Finally, run `./gradlew test` from the `hibernate-rx` directory.
 
-As an alternative, you can start the datastores using the instructions in the [podman.md] file.
+#### Starting database containers with podman
+
+You can start the datastores using the instructions in the [podman.md] file.
 
 [podman.md]:podman.md
 
 Finally, run `./gradlew test` from the `hibernate-rx` directory.
+
+#### Starting databases automatically with Testcontainers
+
+If you have Docker installed, the container instances will be automatically started
+by running the tests if you select the `-Pdocker` profile like so:
+
+    ./gradlew test -Pdocker
+    
+TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in
+a file located at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 
 ## Compatibility
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hibernate-rx-core/build.gradle
+++ b/hibernate-rx-core/build.gradle
@@ -30,6 +30,20 @@ dependencies {
     testImplementation 'io.vertx:vertx-unit:3.8.1'
     testImplementation 'org.postgresql:postgresql:42.1.1'
     testImplementation 'mysql:mysql-connector-java:8.0.19'
-
+    testImplementation 'org.testcontainers:postgresql:1.13.0'
+    testImplementation 'org.testcontainers:mysql:1.13.0'
+    testImplementation 'org.slf4j:slf4j-log4j12:1.7.30'
 }
 
+test {
+  defaultCharacterEncoding = "UTF-8"
+  //useJUnitPlatform()
+  testLogging {
+      displayGranularity 1
+      showStandardStreams = true
+      showStackTraces = true
+      exceptionFormat = 'full'
+      events 'PASSED', 'FAILED', 'SKIPPED'
+  }
+  systemProperty 'docker', project.hasProperty('docker') ? 'true' : 'false'
+}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/BaseRxTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/BaseRxTest.java
@@ -14,6 +14,7 @@ import org.hibernate.rx.service.initiator.RxConnectionPoolProvider;
 import org.hibernate.rx.util.impl.RxUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -41,11 +42,11 @@ public abstract class BaseRxTest {
 			}
 		} );
 	}
-
+	
 	protected Configuration constructConfiguration() {
 		Configuration configuration = new Configuration();
 		configuration.setProperty( AvailableSettings.HBM2DDL_AUTO, "create-drop" );
-		configuration.setProperty( AvailableSettings.URL, "jdbc:postgresql://localhost:5432/hibernate-rx?user=hibernate-rx&password=hibernate-rx" );
+		configuration.setProperty( AvailableSettings.URL, TestConfiguration.getPostgreSQLURL() );
 		configuration.setProperty( AvailableSettings.SHOW_SQL, "true" );
 		return configuration;
 	}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLAutoincrementTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLAutoincrementTest.java
@@ -18,7 +18,7 @@ public class MySQLAutoincrementTest extends BaseRxTest {
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.setProperty( AvailableSettings.URL, "jdbc:mysql://localhost:3306/hibernate-rx?user=hibernate-rx&password=hibernate-rx" );
+		configuration.setProperty( AvailableSettings.URL, TestConfiguration.getMySQLURL() );
 		configuration.setProperty( AvailableSettings.DIALECT, MySQL8Dialect.class.getName());
 		configuration.addAnnotatedClass( Basic.class );
 		return configuration;

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLBasicTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLBasicTest.java
@@ -21,7 +21,7 @@ public class MySQLBasicTest extends BaseRxTest {
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.setProperty( AvailableSettings.URL, "jdbc:mysql://localhost:3306/hibernate-rx?user=hibernate-rx&password=hibernate-rx" );
+		configuration.setProperty( AvailableSettings.URL, TestConfiguration.getMySQLURL() );
 		configuration.setProperty( AvailableSettings.DIALECT, MySQL8Dialect.class.getName());
 		configuration.addAnnotatedClass( Basic.class );
 		return configuration;

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/TestConfiguration.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/TestConfiguration.java
@@ -1,0 +1,40 @@
+package org.hibernate.rx;
+
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class TestConfiguration {
+  
+  private static final boolean USE_DOCKER = Boolean.getBoolean("docker");
+  
+  private static final MySQLContainer<?> mysql = new MySQLContainer<>()
+        .withUsername("hibernate-rx")
+        .withPassword("hibernate-rx")
+        .withDatabaseName("hibernate-rx")
+        .withReuse(true);
+  
+  private static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>()
+        .withUsername("hibernate-rx")
+        .withPassword("hibernate-rx")
+        .withDatabaseName("hibernate-rx")
+        .withReuse(true);
+  
+  public static String getPostgreSQLURL() {
+    if (USE_DOCKER) {
+      postgresql.start();
+      return postgresql.getJdbcUrl() +  "&user=" + postgresql.getUsername() + "&password=" + postgresql.getPassword();
+    } else {
+      return "jdbc:postgresql://localhost:5432/hibernate-rx?user=hibernate-rx&password=hibernate-rx";
+    }
+  }
+  
+  public static String getMySQLURL() {
+    if (USE_DOCKER) {
+      mysql.start();
+      return mysql.getJdbcUrl() +  "?user=" + mysql.getUsername() + "&password=" + mysql.getPassword();
+    } else {
+      return "jdbc:mysql://localhost:3306/hibernate-rx?user=hibernate-rx&password=hibernate-rx";
+    }
+  }
+
+}

--- a/hibernate-rx-core/src/test/resources/log4j.properties
+++ b/hibernate-rx-core/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender=org.apache.log4j.ConsoleAppender
+log4j.appender.layout=org.apache.log4j.PatternLayout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%r %p %c %x - %m%n


### PR DESCRIPTION
Added a docker/testcontainers option of running the tests. People can now run all tests with `./gradlew test -Pdocker` without needing to do any other setup (aside from having docker installed).

Also added TravisCI pipeline that will run all tests in a single stage.