### PR TITLE
86 Reduce test logging during build

### DIFF
--- a/hibernate-rx-core/build.gradle
+++ b/hibernate-rx-core/build.gradle
@@ -40,7 +40,7 @@ test {
   //useJUnitPlatform()
   testLogging {
       displayGranularity 1
-      showStandardStreams = true
+      showStandardStreams = false
       showStackTraces = true
       exceptionFormat = 'full'
       events 'PASSED', 'FAILED', 'SKIPPED'


### PR DESCRIPTION
Issue: https://github.com/hibernate/hibernate-rx/issues/86

I think there is too much information on the console right now during the build and it hides which test has failed. I guess on CI it would be handy but we can find an alternative to enable it if we need it.

A bit unrelated but I've noticed that the execution time for each test doesn't appear. Is there a way to enable it?

Note that running `gradle build -i` will produce the same output when nothing is cached.