### PR TITLE
Get rid of Optional (#52)

### DIFF
--- a/example/src/main/java/org/hibernate/example/rx/Main.java
+++ b/example/src/main/java/org/hibernate/example/rx/Main.java
@@ -3,8 +3,6 @@ package org.hibernate.example.rx;
 import org.hibernate.rx.RxSession;
 import org.hibernate.rx.RxSessionFactory;
 
-import java.util.Optional;
-
 import static javax.persistence.Persistence.createEntityManagerFactory;
 
 public class Main {
@@ -31,7 +29,7 @@ public class Main {
 
 		RxSession session2 = sessionFactory.openRxSession();
 		//retrieve the Book and print its title
-		session2.find(Book.class, book.id).thenApply(Optional::get)
+		session2.find(Book.class, book.id)
 				.thenAccept( bOOk -> System.out.println(bOOk.title + " is a great book!") )
 				.thenAccept( $ -> session2.close() )
 				.toCompletableFuture()
@@ -39,7 +37,7 @@ public class Main {
 
 		RxSession session3 = sessionFactory.openRxSession();
 		//retrieve the Book and delete it
-		session3.find(Book.class, book.id).thenApply(Optional::get)
+		session3.find(Book.class, book.id)
 				.thenCompose( bOOk -> session3.remove(bOOk))
 				.thenCompose( $ -> session3.flush() )
 				.thenAccept( $ -> session2.close() )

--- a/hibernate-rx-api/src/main/java/org/hibernate/rx/RxSession.java
+++ b/hibernate-rx-api/src/main/java/org/hibernate/rx/RxSession.java
@@ -4,7 +4,6 @@ import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -49,7 +48,7 @@ public interface RxSession {
 	 * 
 	 * @see javax.persistence.EntityManager#find(Class, Object) 
 	 */
-	<T> CompletionStage<Optional<T>> find(Class<T> entityClass, Object id);
+	<T> CompletionStage<T> find(Class<T> entityClass, Object id);
 
 	/**
 	 * Asynchronously return the persistent instances of the given entity
@@ -176,7 +175,7 @@ public interface RxSession {
 	 *
 	 * @return the fetched association, via a {@code CompletionStage}
 	 */
-	<T> CompletionStage<Optional<T>> fetch(T association);
+	<T> CompletionStage<T> fetch(T association);
 
 	/**
 	 * Create an instance of {@link RxQuery} for the given HQL/JPQL query

--- a/hibernate-rx-api/src/test/java/org/hibernate/rx/MockRxSession.java
+++ b/hibernate-rx-api/src/test/java/org/hibernate/rx/MockRxSession.java
@@ -4,12 +4,10 @@ import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /**
  * Depending of what we want to test, this session can be configured using the {@link Builder} to
@@ -20,12 +18,10 @@ import java.util.function.Supplier;
  */
 public class MockRxSession implements RxSession {
 
-	private BiFunction loadFunction = (type, id) -> {
-		return null;
-	};
+	private BiFunction loadFunction = (type, id) -> null;
 
 	private Consumer persistFunction = obj -> {};
-		private Consumer removeFunction = obj -> {};
+	private Consumer removeFunction = obj -> {};
 
 		/**
 		 * Assign the functions that simulate the access to a source for CRUD.
@@ -56,17 +52,8 @@ public class MockRxSession implements RxSession {
 		}
 
 	@Override
-	public <T> CompletionStage<Optional<T>> find(Class<T> entityClass, final Object id) {
-		Supplier<Optional<T>> supplier = () -> {
-			Object result = loadFunction.apply( entityClass, id );
-			if ( result == null ) {
-				return Optional.empty();
-			}
-			else {
-				return Optional.of( (T) result );
-			}
-		};
-		return CompletableFuture.supplyAsync( supplier );
+	public <T> CompletionStage<T> find(Class<T> entityClass, final Object id) {
+		return CompletableFuture.supplyAsync(() -> (T) loadFunction.apply( entityClass, id ));
 	}
 
 	@Override
@@ -120,8 +107,8 @@ public class MockRxSession implements RxSession {
 	}
 
 	@Override
-	public <T> CompletionStage<Optional<T>> fetch(T association) {
-		return CompletableFuture.completedFuture( Optional.ofNullable(association) );
+	public <T> CompletionStage<T> fetch(T association) {
+		return CompletableFuture.completedFuture( association );
 	}
 
 	@Override

--- a/hibernate-rx-api/src/test/java/org/hibernate/rx/RxSessionApiTest.java
+++ b/hibernate-rx-api/src/test/java/org/hibernate/rx/RxSessionApiTest.java
@@ -2,7 +2,6 @@ package org.hibernate.rx;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ public class RxSessionApiTest {
 		session.find( GuineaPig.class, 1 )
 				.whenComplete( (result, err) -> {
 					try {
-						assertThat( (Optional) result ).isNotPresent();
+						assertThat( result ).isNull();
 						testContext.completeNow();
 					}
 					catch (Throwable e) {
@@ -53,7 +52,7 @@ public class RxSessionApiTest {
 		session.find( GuineaPig.class, pig.getId() )
 				.whenComplete( (result, err) -> {
 					try {
-						assertThat( (Optional) result ).isPresent().hasValue( pig );
+						assertThat( result ).isNotNull().isEqualTo( pig );
 						testContext.completeNow();
 					}
 					catch (Throwable e) {

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/RxSessionInternal.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/RxSessionInternal.java
@@ -9,7 +9,6 @@ import javax.persistence.LockModeType;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -31,7 +30,7 @@ public interface RxSessionInternal extends Session {
 
 	RxActionQueue getRxActionQueue();
 
-	<T> CompletionStage<Optional<T>> rxFetch(T association);
+	<T> CompletionStage<T> rxFetch(T association);
 
 	CompletionStage<Void> rxPersist(Object entity);
 
@@ -53,11 +52,11 @@ public interface RxSessionInternal extends Session {
 
 	CompletionStage<?> rxRefresh(Object child, IdentitySet refreshedAlready);
 
-	<T> CompletionStage<Optional<T>> rxGet(
+	<T> CompletionStage<T> rxGet(
 			Class<T> entityClass,
 			Serializable id);
 
-	<T> CompletionStage<Optional<T>> rxFind(
+	<T> CompletionStage<T> rxFind(
 			Class<T> entityClass,
 			Object primaryKey,
 			LockModeType lockModeType,

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/engine/impl/CascadingActions.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/engine/impl/CascadingActions.java
@@ -51,8 +51,7 @@ public class CascadingActions {
 			LOG.tracev( "Cascading to delete: {0}", entityName );
 			return session.unwrap(RxSessionInternal.class).rxFetch(child)
 					.thenCompose( c -> session.unwrap(RxSessionInternal.class)
-							.rxRemove( c.orElseThrow(AssertionError::new),
-									isCascadeDeleteEnabled, context ) );
+							.rxRemove( c, isCascadeDeleteEnabled, context ) );
 		}
 	};
 

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/AbstractRxSaveEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/AbstractRxSaveEventListener.java
@@ -31,7 +31,6 @@ import org.hibernate.type.TypeHelper;
 
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -82,12 +81,11 @@ abstract class AbstractRxSaveEventListener<C>
 		);
 	}
 
-	private static Serializable assignIdIfNecessary(Optional<?> generatedId, Object entity, String entityName, EventSource source) {
+	private static Serializable assignIdIfNecessary(Object generatedId, Object entity, String entityName, EventSource source) {
 		EntityPersister persister = source.getEntityPersister(entityName, entity);
-		if ( generatedId.isPresent() ) {
-			Object id = generatedId.get();
-			if (id instanceof Long) {
-				Long longId = (Long) id;
+		if ( generatedId != null ) {
+			if (generatedId instanceof Long) {
+				Long longId = (Long) generatedId;
 				Type identifierType = persister.getIdentifierType();
 				if (identifierType == LongType.INSTANCE) {
 					return longId;
@@ -101,7 +99,7 @@ abstract class AbstractRxSaveEventListener<C>
 				}
 			}
 			else {
-				return (Serializable) id;
+				return (Serializable) generatedId;
 			}
 		}
 		else {

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxLoadEventListener.java
@@ -319,7 +319,7 @@ public class DefaultRxLoadEventListener implements LoadEventListener, RxLoadEven
 					final EntityEntry entry = persistenceContext.getEntry( managed );
 					final Status status = entry.getStatus();
 					if ( status == Status.DELETED || status == Status.GONE ) {
-						return RxUtil.completedFuture( null );
+						return RxUtil.nullFuture();
 					}
 				}
 				return RxUtil.completedFuture( managed );
@@ -430,7 +430,7 @@ public class DefaultRxLoadEventListener implements LoadEventListener, RxLoadEven
 					} );
 		}
 		else {
-			implStage = RxUtil.completedFuture( null );
+			implStage = RxUtil.nullFuture();
 		}
 
 		return implStage.thenApply( impl -> persistenceContext.narrowProxy( proxy, persister, keyToLoad, impl ) );

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxMergeEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxMergeEventListener.java
@@ -309,9 +309,8 @@ public class DefaultRxMergeEventListener extends AbstractRxSaveEventListener imp
 
 		return source.unwrap(RxSessionInternal.class)
 				.rxGet( (Class<?>) persister.getMappedClass(), clonedIdentifier )
-				.thenCompose(option -> {
-					if ( option.isPresent() ) {
-						Object result = option.get();
+				.thenCompose(result -> {
+					if ( result!=null ) {
 						// before cascade!
 						copyCache.put(entity, result, true);
 

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/PoolConnection.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/PoolConnection.java
@@ -5,7 +5,6 @@ import io.vertx.axle.sqlclient.*;
 import org.hibernate.rx.RxSession;
 import org.hibernate.rx.service.RxConnection;
 
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
@@ -58,9 +57,9 @@ public class PoolConnection implements RxConnection {
 	}
 
 	@Override
-	public CompletionStage<Optional<Long>> updateReturning(String sql, Tuple parameters) {
+	public CompletionStage<Long> updateReturning(String sql, Tuple parameters) {
 		return preparedQuery( sql, parameters )
-				.thenApply( rows -> Optional.ofNullable( rows.property(MySQLClient.LAST_INSERTED_ID) ) );
+				.thenApply( rows -> rows.property(MySQLClient.LAST_INSERTED_ID) );
 	}
 
 	@Override

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/RxSessionImpl.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/RxSessionImpl.java
@@ -9,7 +9,6 @@ import org.hibernate.rx.RxSessionInternal;
 import javax.persistence.LockModeType;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -32,7 +31,7 @@ public class RxSessionImpl implements RxSession {
 	}
 
 	@Override
-	public <T> CompletionStage<Optional<T>> fetch(T association) {
+	public <T> CompletionStage<T> fetch(T association) {
 		return delegate.rxFetch(association);
 	}
 
@@ -44,7 +43,7 @@ public class RxSessionImpl implements RxSession {
 	}
 
 	@Override
-	public <T> CompletionStage<Optional<T>> find(Class<T> entityClass, Object primaryKey) {
+	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey) {
 		return delegate.rxFind( entityClass, primaryKey, null, null );
 	}
 
@@ -53,18 +52,18 @@ public class RxSessionImpl implements RxSession {
 		return delegate.rxFind( entityClass, ids );
 	}
 
-	public <T> CompletionStage<Optional<T>> find(
+	public <T> CompletionStage<T> find(
 			Class<T> entityClass,
 			Object primaryKey,
 			Map<String, Object> properties) {
 		return delegate.rxFind( entityClass, primaryKey, null, properties );
 	}
 
-	public <T> CompletionStage<Optional<T>> find(Class<T> entityClass, Object primaryKey, LockModeType lockModeType) {
+	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey, LockModeType lockModeType) {
 		return delegate.rxFind( entityClass, primaryKey, lockModeType, null );
 	}
 
-	public <T> CompletionStage<Optional<T>> find(
+	public <T> CompletionStage<T> find(
 			Class<T> entityClass,
 			Object primaryKey,
 			LockModeType lockModeType,

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/RxSessionInternalImpl.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/RxSessionInternalImpl.java
@@ -107,14 +107,11 @@ public class RxSessionInternalImpl extends SessionImpl implements RxSessionInter
 			LazyInitializer initializer = ((HibernateProxy) association).getHibernateLazyInitializer();
 			//TODO: is this correct?
 			// SessionImpl doesn't use IdentifierLoadAccessImpl for initializing proxies
-			return new RxIdentifierLoadAccessImpl<T>( initializer.getEntityName() )
-					.fetch( initializer.getIdentifier() )
-					.thenApply( optional -> {
-						if ( optional==null ) {
-							throw new ObjectNotFoundException( initializer.getIdentifier(), initializer.getEntityName() );
-						}
-						return optional;
-					})
+			String entityName = initializer.getEntityName();
+			Serializable identifier = initializer.getIdentifier();
+			return new RxIdentifierLoadAccessImpl<T>( entityName )
+					.fetch( identifier )
+					.thenApply( SessionUtil.checkEntityFound( this, entityName, identifier ) )
 					.thenApply( entity -> {
 						initializer.setSession( this );
 						initializer.setImplementation( entity );

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/SessionUtil.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/impl/SessionUtil.java
@@ -1,0 +1,25 @@
+package org.hibernate.rx.impl;
+
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+public class SessionUtil {
+
+	public static void throwEntityNotFound(SessionImplementor session, String entityName, Serializable identifier) {
+		session.getFactory().getEntityNotFoundDelegate().handleEntityNotFound( entityName, identifier );
+	}
+
+	public static <T> T checkEntityFound(SessionImplementor session, String entityName, Serializable identifier, T optional) {
+		if ( optional==null ) {
+			throwEntityNotFound(session, entityName, identifier);
+		}
+		return optional;
+	}
+
+	public static <T> Function<T, T> checkEntityFound(SessionImplementor session, String entityName, Serializable identifier) {
+		return optional -> checkEntityFound(session, entityName, identifier, optional);
+	}
+
+}

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/loader/entity/impl/RxAbstractEntityLoader.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/loader/entity/impl/RxAbstractEntityLoader.java
@@ -21,7 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -33,7 +32,7 @@ public class RxAbstractEntityLoader extends AbstractEntityLoader {
 	}
 
 	@Override
-	protected CompletionStage<Optional<Object>> load(
+	protected CompletionStage<Object> load(
 			SharedSessionContractImplementor session,
 			Object id,
 			Object optionalObject,
@@ -53,12 +52,12 @@ public class RxAbstractEntityLoader extends AbstractEntityLoader {
 		).thenApply( list -> {
 			switch ( list.size() ) {
 				case 1:
-					return Optional.ofNullable( list.get( 0 ) );
+					return list.get( 0 );
 				case 0:
-					return Optional.empty();
+					return null;
 				default:
 					if ( getCollectionOwners() != null ) {
-						return Optional.ofNullable( list.get( 0 ) );
+						return list.get( 0 );
 					}
 			}
 			throw new HibernateException(
@@ -216,24 +215,24 @@ public class RxAbstractEntityLoader extends AbstractEntityLoader {
 
 
 	@Override
-	public CompletionStage<Optional<Object>> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session) {
+	public CompletionStage<Object> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session) {
 		// this form is deprecated!
 		return load( id, optionalObject, session, LockOptions.NONE, null );
 	}
 
 	@Override
-	public CompletionStage<Optional<Object>> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, Boolean readOnly) {
+	public CompletionStage<Object> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, Boolean readOnly) {
 		// this form is deprecated!
 		return load( id, optionalObject, session, LockOptions.NONE, readOnly );
 	}
 
 	@Override
-	public CompletionStage<Optional<Object>> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions) {
+	public CompletionStage<Object> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions) {
 		return load( id, optionalObject, session, lockOptions, null );
 	}
 
 	@Override
-	public CompletionStage<Optional<Object>> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions, Boolean readOnly) {
+	public CompletionStage<Object> load(Serializable id, Object optionalObject, SharedSessionContractImplementor session, LockOptions lockOptions, Boolean readOnly) {
 		return load( session, id, optionalObject, id, lockOptions, readOnly );
 	}
 }

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/IdentifierGeneration.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/IdentifierGeneration.java
@@ -21,7 +21,6 @@ import org.hibernate.mapping.SimpleValue;
 import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.rx.util.impl.RxUtil;
 
-import java.util.Optional;
 import java.util.Properties;
 
 import static org.hibernate.id.enhanced.SequenceStyleGenerator.CATALOG;
@@ -101,15 +100,15 @@ public class IdentifierGeneration {
 					.getIdentityColumnSupport().supportsInsertSelectIdentity() ) {
 				throw new HibernateException("getGeneratedKeys() is disabled");
 			}
-			return f -> RxUtil.completedFuture( Optional.empty() );
+			return f -> RxUtil.nullFuture();
 		}
 		else if (identifierGenerator instanceof Assigned
 				|| identifierGenerator instanceof CompositeNestedGeneratedValueGenerator) {
 			//TODO!
-			return f -> RxUtil.completedFuture( Optional.empty() );
+			return f -> RxUtil.nullFuture();
 		}
 		else {
-			return f -> RxUtil.completedFuture( Optional.of( identifierGenerator.generate(f, null) ) );
+			return f -> RxUtil.completedFuture( identifierGenerator.generate(f, null) );
 		}
 	}
 

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAbstractEntityPersister.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAbstractEntityPersister.java
@@ -30,7 +30,6 @@ import java.io.Serializable;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -271,7 +270,7 @@ public interface RxAbstractEntityPersister extends RxEntityPersister, OuterJoinL
 				sql = sql + " returning " + identifierColumnName;
 			}
 			return queryExecutor().updateReturning( sql, insert.getParametersAsArray(), factory )
-					.thenApply(Optional::get);
+					.thenApply( id -> id );
 		}
 		else {
 			//use an extra round trip to fetch the id
@@ -281,9 +280,9 @@ public interface RxAbstractEntityPersister extends RxEntityPersister, OuterJoinL
 							identifierColumnName,
 							Types.INTEGER
 					);
-			return queryExecutor().update( sql, insert.getParametersAsArray(), factory)
+			return queryExecutor().update( sql, insert.getParametersAsArray(), factory )
 					.thenCompose( v -> queryExecutor().selectLong(selectIdSql, new Object[0], factory) )
-					.thenApply(Optional::get);
+					.thenApply( id -> id );
 		}
 
 	}

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAbstractEntityPersister.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAbstractEntityPersister.java
@@ -96,7 +96,7 @@ public interface RxAbstractEntityPersister extends RxEntityPersister, OuterJoinL
 		preInsertInMemoryValueGeneration( fields, object, session, delegate() );
 
 		final int span = delegate().getTableSpan();
-		CompletionStage<Serializable> stage = RxUtil.completedFuture(null);
+		CompletionStage<Serializable> stage = RxUtil.nullFuture();
 		if ( delegate().getEntityMetamodel().isDynamicInsert() ) {
 			// For the case of dynamic-insert="true", we need to generate the INSERT SQL
 			boolean[] notNull = delegate().getPropertiesToInsert( fields );

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxEntityPersister.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxEntityPersister.java
@@ -12,7 +12,6 @@ import org.jboss.logging.Logger;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -81,11 +80,11 @@ public interface RxEntityPersister extends EntityPersister {
 			SessionImplementor session,
 			MultiLoadOptions loadOptions);
 
-	default CompletionStage<Optional<Object>> rxLoad(Serializable id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	default CompletionStage<Object> rxLoad(Serializable id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		return rxLoad( id, optionalObject, lockOptions, session, null );
 	}
 
-	default CompletionStage<Optional<Object>> rxLoad(Serializable id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
+	default CompletionStage<Object> rxLoad(Serializable id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
 		if ( log.isTraceEnabled() ) {
 			log.tracev( "Fetching entity: {0}", MessageHelper.infoString( this, id, getFactory() ) );
 		}

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxIdentifierGenerator.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxIdentifierGenerator.java
@@ -2,7 +2,6 @@ package org.hibernate.rx.persister.entity.impl;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -18,5 +17,5 @@ public interface RxIdentifierGenerator<Id> {
 	/**
 	 * Returns a generated identifier, via a {@link CompletionStage}.
 	 */
-	CompletionStage<Optional<Id>> generate(SharedSessionContractImplementor session);
+	CompletionStage<Id> generate(SharedSessionContractImplementor session);
 }

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/SequenceRxIdentifierGenerator.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/SequenceRxIdentifierGenerator.java
@@ -13,7 +13,6 @@ import org.hibernate.persister.spi.PersisterCreationContext;
 import org.hibernate.rx.impl.RxQueryExecutor;
 import org.hibernate.rx.util.impl.RxUtil;
 
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletionStage;
 
@@ -62,8 +61,8 @@ public class SequenceRxIdentifierGenerator implements RxIdentifierGenerator<Long
 	}
 
 	@Override
-	public CompletionStage<Optional<Long>> generate(SharedSessionContractImplementor session) {
-		return sql==null ? RxUtil.completedFuture(Optional.empty())
+	public CompletionStage<Long> generate(SharedSessionContractImplementor session) {
+		return sql==null ? RxUtil.nullFuture()
 				: queryExecutor.selectLong( sql, new Object[0], session.getFactory() );
 	}
 }

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/service/RxConnection.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/service/RxConnection.java
@@ -1,6 +1,5 @@
 package org.hibernate.rx.service;
 
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
@@ -27,7 +26,7 @@ public interface RxConnection {
 
 	CompletionStage<RowSet<Row>> preparedQuery(String query);
 
-	CompletionStage<Optional<Long>> updateReturning(String sql, Tuple parameters);
+	CompletionStage<Long> updateReturning(String sql, Tuple parameters);
 
 	CompletionStage<RowSet<Row>> preparedQuery(String sql, Tuple parameters);
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/AutoincrementTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/AutoincrementTest.java
@@ -54,9 +54,8 @@ public class AutoincrementTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s2 ->
 					s2.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							context.assertTrue( option.isPresent() );
-							Basic basic = option.get();
+						.thenCompose( basic -> {
+							context.assertNotNull( basic );
 							context.assertTrue( basic.loaded );
 							context.assertEquals( basic.string, basik.string);
 							context.assertEquals( basic.decimal.floatValue(), basik.decimal.floatValue());
@@ -81,7 +80,7 @@ public class AutoincrementTest extends BaseRxTest {
 							return s2.persist(basic.parent)
 									.thenCompose( v -> s2.flush() )
 									.thenAccept(v -> {
-										context.assertTrue( option.isPresent() );
+										context.assertNotNull( basic );
 										context.assertTrue( basic.postUpdated && basic.preUpdated );
 										context.assertFalse( basic.postPersisted && basic.prePersisted );
 										context.assertTrue( basic.parent.postPersisted && basic.parent.prePersisted );
@@ -91,8 +90,7 @@ public class AutoincrementTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s3 ->
 					s3.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							Basic basic = option.get();
+						.thenCompose( basic -> {
 							context.assertFalse( basic.postUpdated && basic.preUpdated );
 							context.assertFalse( basic.postPersisted && basic.prePersisted );
 							context.assertEquals( basic.version, 1 );
@@ -109,7 +107,7 @@ public class AutoincrementTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s4 ->
 						s4.find( Basic.class, basik.getId() )
-							.thenAccept( option -> context.assertFalse( option.isPresent() ) ))
+							.thenAccept(context::assertNull))
 		);
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/BasicTypesAndCallbacksTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/BasicTypesAndCallbacksTest.java
@@ -54,9 +54,8 @@ public class BasicTypesAndCallbacksTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s2 ->
 					s2.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							context.assertTrue( option.isPresent() );
-							Basic basic = option.get();
+						.thenCompose( basic -> {
+							context.assertNotNull( basic );
 							context.assertTrue( basic.loaded );
 							context.assertEquals( basic.string, basik.string);
 							context.assertEquals( basic.decimal.floatValue(), basik.decimal.floatValue());
@@ -81,7 +80,7 @@ public class BasicTypesAndCallbacksTest extends BaseRxTest {
 							return s2.persist(basic.parent)
 									.thenCompose( v -> s2.flush() )
 									.thenAccept(v -> {
-										context.assertTrue( option.isPresent() );
+										context.assertNotNull( basic );
 										context.assertTrue( basic.postUpdated && basic.preUpdated );
 										context.assertFalse( basic.postPersisted && basic.prePersisted );
 										context.assertTrue( basic.parent.postPersisted && basic.parent.prePersisted );
@@ -91,8 +90,7 @@ public class BasicTypesAndCallbacksTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s3 ->
 					s3.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							Basic basic = option.get();
+						.thenCompose( basic -> {
 							context.assertFalse( basic.postUpdated && basic.preUpdated );
 							context.assertFalse( basic.postPersisted && basic.prePersisted );
 							context.assertEquals( basic.version, 1 );
@@ -114,7 +112,7 @@ public class BasicTypesAndCallbacksTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s4 ->
 						s4.find( Basic.class, basik.getId() )
-							.thenAccept( option -> context.assertFalse( option.isPresent() ) ))
+							.thenAccept(context::assertNull))
 		);
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/CascadeTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/CascadeTest.java
@@ -39,9 +39,8 @@ public class CascadeTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s2 ->
 					s2.find( Node.class, basik.getId() )
-						.thenCompose( option -> {
-							context.assertTrue( option.isPresent() );
-							Node node = option.get();
+						.thenCompose( node -> {
+							context.assertNotNull( node );
 							context.assertTrue( node.loaded );
 							context.assertEquals( node.string, basik.string);
 							context.assertEquals( node.version, 0 );
@@ -51,7 +50,7 @@ public class CascadeTest extends BaseRxTest {
 							node.parent = new Node("New Parent");
 							return s2.flush()
 									.thenAccept(v -> {
-										context.assertTrue( option.isPresent() );
+										context.assertNotNull( node );
 										context.assertTrue( node.postUpdated && node.preUpdated );
 										context.assertFalse( node.postPersisted && node.prePersisted );
 										context.assertTrue( node.parent.postPersisted && node.parent.prePersisted );
@@ -61,15 +60,13 @@ public class CascadeTest extends BaseRxTest {
 						.thenCompose(v -> openSession())
 						.thenCompose(s2 ->
 								s2.find( Node.class, basik.getId() )
-										.thenCompose( option -> {
-											context.assertTrue( option.isPresent() );
-											Node node = option.get();
+										.thenCompose( node -> {
+											context.assertNotNull( node );
 											context.assertEquals( node.version, 1 );
 											context.assertEquals( node.string, "Adopted");
 											return s2.fetch( node.parent )
-													.thenCompose( opt -> {
-														context.assertTrue( opt.isPresent() );
-														Node parent = opt.get();
+													.thenCompose( parent -> {
+														context.assertNotNull( parent );
 														return connection().preparedQuery("update Node set string = upper(string)")
 																.thenCompose(v -> s2.refresh(node))
 																.thenAccept(v -> {
@@ -81,8 +78,7 @@ public class CascadeTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s3 ->
 					s3.find( Node.class, basik.getId() )
-						.thenCompose( option -> {
-							Node node = option.get();
+						.thenCompose( node -> {
 							context.assertFalse( node.postUpdated && node.preUpdated );
 							context.assertFalse( node.postPersisted && node.prePersisted );
 							context.assertEquals( node.version, 1 );
@@ -103,7 +99,7 @@ public class CascadeTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s4 ->
 						s4.find( Node.class, basik.getId() )
-							.thenAccept( option -> context.assertFalse( option.isPresent() ) ))
+							.thenAccept(context::assertNull))
 		);
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/CompositeIdTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/CompositeIdTest.java
@@ -11,7 +11,6 @@ import javax.persistence.IdClass;
 import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 public class CompositeIdTest extends BaseRxTest {
@@ -135,7 +134,7 @@ public class CompositeIdTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( session ->
 							session.find( GuineaPig.class, new Pig(5, "Aloi") )
-								.thenCompose( aloi -> session.remove( aloi.get() ) )
+								.thenCompose( aloi -> session.remove( aloi ) )
 								.thenCompose( v -> session.flush() )
 								.thenCompose( v -> selectNameFromId( 5 ) )
 								.thenAccept( ret -> context.assertNull( ret ) ) )
@@ -151,8 +150,8 @@ public class CompositeIdTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( session ->
 							session.find( GuineaPig.class, new Pig(5, "Aloi") )
-								.thenAccept( o -> {
-									GuineaPig pig = o.orElseThrow( () -> new AssertionError( "Guinea pig not found" ) );
+								.thenAccept( pig -> {
+									context.assertNotNull( pig );
 									// Checking we are actually changing the name
 									context.assertNotEquals( pig.getWeight(), NEW_WEIGHT );
 									pig.setWeight( NEW_WEIGHT );
@@ -163,11 +162,11 @@ public class CompositeIdTest extends BaseRxTest {
 		);
 	}
 
-	private void assertThatPigsAreEqual(TestContext context, GuineaPig expected, Optional<GuineaPig> actual) {
-		context.assertTrue( actual.isPresent() );
-		context.assertEquals( expected.getId(), actual.get().getId() );
-		context.assertEquals( expected.getName(), actual.get().getName() );
-		context.assertEquals( expected.getWeight(), actual.get().getWeight() );
+	private void assertThatPigsAreEqual(TestContext context, GuineaPig expected, GuineaPig actual) {
+		context.assertNotNull( actual );
+		context.assertEquals( expected.getId(), actual.getId() );
+		context.assertEquals( expected.getName(), actual.getName() );
+		context.assertEquals( expected.getWeight(), actual.getWeight() );
 	}
 
 	static final class Pig implements Serializable {

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/EagerManyToOneAssociationTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/EagerManyToOneAssociationTest.java
@@ -31,15 +31,15 @@ public class EagerManyToOneAssociationTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Author.class, author.getId() ) )
 						.thenAccept( optionalAuthor -> {
-							context.assertTrue( optionalAuthor.isPresent() );
-							context.assertEquals( author, optionalAuthor.get() );
-							context.assertEquals( book, optionalAuthor.get().getBook()  );
+							context.assertNotNull( optionalAuthor );
+							context.assertEquals( author, optionalAuthor );
+							context.assertEquals( book, optionalAuthor.getBook()  );
 						} )
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Book.class, book.getId() ) )
 						.thenAccept( optionalBook -> {
-							context.assertTrue( optionalBook.isPresent() );
-							context.assertEquals( book, optionalBook.get() );
+							context.assertNotNull( optionalBook );
+							context.assertEquals( book, optionalBook );
 						})
 		);
 	}
@@ -60,9 +60,9 @@ public class EagerManyToOneAssociationTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Author.class, neilGaiman.getId() ) )
 						.thenAccept( optionalAuthor -> {
-							context.assertTrue( optionalAuthor.isPresent() );
-							context.assertEquals( neilGaiman, optionalAuthor.get() );
-							context.assertEquals( goodOmens, optionalAuthor.get().getBook()  );
+							context.assertNotNull( optionalAuthor );
+							context.assertEquals( neilGaiman, optionalAuthor );
+							context.assertEquals( goodOmens, optionalAuthor.getBook()  );
 						} )
 		);
 	}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/EagerOneToManyAssociationTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/EagerOneToManyAssociationTest.java
@@ -61,10 +61,10 @@ public class EagerOneToManyAssociationTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Book.class, goodOmens.getId() ) )
 						.thenAccept( optionalBook -> {
-							context.assertTrue( optionalBook.isPresent() );
-							context.assertEquals( 2, optionalBook.get().getAuthors().size() );
-							context.assertTrue( optionalBook.get().getAuthors().contains( neilGaiman )  );
-							context.assertTrue( optionalBook.get().getAuthors().contains( terryPratchett )  );
+							context.assertNotNull( optionalBook );
+							context.assertEquals( 2, optionalBook.getAuthors().size() );
+							context.assertTrue( optionalBook.getAuthors().contains( neilGaiman )  );
+							context.assertTrue( optionalBook.getAuthors().contains( terryPratchett )  );
 						} )
 		);
 	}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/EagerOneToOneAssociationTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/EagerOneToOneAssociationTest.java
@@ -32,7 +32,7 @@ public class EagerOneToOneAssociationTest extends BaseRxTest {
 						.thenCompose( s -> s.flush() )
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Book.class, 5 ) )
-						.thenAccept( optionalBook -> context.assertTrue( optionalBook.isPresent() ) )
+						.thenAccept(context::assertNotNull)
 		);
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/JoinedSubclassInheritanceTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/JoinedSubclassInheritanceTest.java
@@ -33,9 +33,9 @@ public class JoinedSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s2 -> s2.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 						} )
 		);
 	}
@@ -53,9 +53,9 @@ public class JoinedSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( s -> s.flush() )
 						.thenCompose( s -> s.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 						} )
 		);
 	}
@@ -74,9 +74,9 @@ public class JoinedSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertFalse(book.get() instanceof SpellBook);
-							context.assertEquals(book.get().getTitle(), "The Boy, The Mole, The Fox and The Horse");
+							context.assertNotNull(book);
+							context.assertFalse(book instanceof SpellBook);
+							context.assertEquals(book.getTitle(), "The Boy, The Mole, The Fox and The Horse");
 						}));
 	}
 
@@ -93,9 +93,9 @@ public class JoinedSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertTrue(book.get() instanceof SpellBook);
-							context.assertEquals(book.get().getTitle(), "Necronomicon");
+							context.assertNotNull(book);
+							context.assertTrue(book instanceof SpellBook);
+							context.assertEquals(book.getTitle(), "Necronomicon");
 						}));
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/LazyManyToOneAssociationTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/LazyManyToOneAssociationTest.java
@@ -33,15 +33,15 @@ public class LazyManyToOneAssociationTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( s -> s.enableFetchProfile("withBook").find( Author.class, author.getId() )
 								.thenAccept( optionalAuthor -> {
-									context.assertTrue( optionalAuthor.isPresent() );
-									context.assertEquals( author, optionalAuthor.get() );
-									context.assertEquals( book, optionalAuthor.get().getBook() );
+									context.assertNotNull( optionalAuthor );
+									context.assertEquals( author, optionalAuthor );
+									context.assertEquals( book, optionalAuthor.getBook() );
 								}))
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Book.class, book.getId() ) )
 						.thenAccept( optionalBook -> {
-							context.assertTrue( optionalBook.isPresent() );
-							context.assertEquals( book, optionalBook.get() );
+							context.assertNotNull( optionalBook );
+							context.assertEquals( book, optionalBook );
 						})
 		);
 	}
@@ -61,19 +61,19 @@ public class LazyManyToOneAssociationTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Author.class, author.getId() )
 								.thenCompose( optionalAuthor -> {
-									context.assertTrue( optionalAuthor.isPresent() );
-									context.assertEquals( author, optionalAuthor.get() );
-									return s.fetch( optionalAuthor.get().getBook() ).thenAccept(
+									context.assertNotNull( optionalAuthor );
+									context.assertEquals( author, optionalAuthor );
+									return s.fetch( optionalAuthor.getBook() ).thenAccept(
 											fetchedBook -> {
-												context.assertTrue( fetchedBook.isPresent() );
-												context.assertEquals( book, fetchedBook.get() );
+												context.assertNotNull( fetchedBook );
+												context.assertEquals( book, fetchedBook );
 											});
 								}))
 						.thenCompose( v -> openSession())
 						.thenCompose( s -> s.find( Book.class, book.getId() ) )
 						.thenAccept( optionalBook -> {
-							context.assertTrue( optionalBook.isPresent() );
-							context.assertEquals( book, optionalBook.get() );
+							context.assertNotNull( optionalBook );
+							context.assertEquals( book, optionalBook );
 						})
 		);
 	}
@@ -95,12 +95,12 @@ public class LazyManyToOneAssociationTest extends BaseRxTest {
 						.thenCompose( s ->
 							s.find( Author.class, neilGaiman.getId() )
 								.thenCompose( optionalAuthor -> {
-									context.assertTrue( optionalAuthor.isPresent() );
-									context.assertEquals( neilGaiman, optionalAuthor.get() );
-									return s.fetch( optionalAuthor.get().getBook() ).thenAccept(
+									context.assertNotNull( optionalAuthor );
+									context.assertEquals( neilGaiman, optionalAuthor );
+									return s.fetch( optionalAuthor.getBook() ).thenAccept(
 											fetchedBook -> {
-												context.assertTrue( fetchedBook.isPresent() );
-												context.assertEquals( goodOmens, fetchedBook.get() );
+												context.assertNotNull( fetchedBook );
+												context.assertEquals( goodOmens, fetchedBook );
 											});
 								}))
 		);

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/LazyOneToManyAssociationWithFetchTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/LazyOneToManyAssociationWithFetchTest.java
@@ -36,12 +36,12 @@ public class LazyOneToManyAssociationWithFetchTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( s -> s.find( Book.class, goodOmens.getId() )
 								.thenCompose(
-										book -> s.fetch( book.get().getAuthors())
+										book -> s.fetch( book.getAuthors())
 								) )
 						.thenAccept( optionalAssociation -> {
-							context.assertTrue(optionalAssociation.isPresent());
-							context.assertTrue(optionalAssociation.get().contains(neilGaiman));
-							context.assertTrue(optionalAssociation.get().contains(terryPratchett));
+							context.assertNotNull(optionalAssociation);
+							context.assertTrue(optionalAssociation.contains(neilGaiman));
+							context.assertTrue(optionalAssociation.contains(terryPratchett));
 
 						} )
 		);

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLAutoincrementTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLAutoincrementTest.java
@@ -81,9 +81,8 @@ public class MySQLAutoincrementTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s2 ->
 					s2.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							context.assertTrue( option.isPresent() );
-							Basic basic = option.get();
+						.thenCompose( basic -> {
+							context.assertNotNull( basic );
 							context.assertTrue( basic.loaded );
 							context.assertEquals( basic.string, basik.string);
 //							context.assertEquals( basic.decimal.floatValue(), basik.decimal.floatValue());
@@ -108,7 +107,7 @@ public class MySQLAutoincrementTest extends BaseRxTest {
 							return s2.persist(basic.parent)
 									.thenCompose( v -> s2.flush() )
 									.thenAccept(v -> {
-										context.assertTrue( option.isPresent() );
+										context.assertNotNull( basic );
 										context.assertTrue( basic.postUpdated && basic.preUpdated );
 										context.assertFalse( basic.postPersisted && basic.prePersisted );
 										context.assertTrue( basic.parent.postPersisted && basic.parent.prePersisted );
@@ -118,8 +117,7 @@ public class MySQLAutoincrementTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s3 ->
 					s3.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							Basic basic = option.get();
+						.thenCompose( basic -> {
 							context.assertFalse( basic.postUpdated && basic.preUpdated );
 							context.assertFalse( basic.postPersisted && basic.prePersisted );
 							context.assertEquals( basic.version, 1 );
@@ -132,7 +130,7 @@ public class MySQLAutoincrementTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s4 ->
 						s4.find( Basic.class, basik.getId() )
-							.thenAccept( option -> context.assertFalse( option.isPresent() ) ))
+							.thenAccept( context::assertNull))
 		);
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLBasicTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/MySQLBasicTest.java
@@ -80,9 +80,8 @@ public class MySQLBasicTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s2 ->
 					s2.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							context.assertTrue( option.isPresent() );
-							Basic basic = option.get();
+						.thenCompose( basic -> {
+							context.assertNotNull( basic );
 							context.assertTrue( basic.loaded );
 							context.assertEquals( basic.string, basik.string);
 //							context.assertEquals( basic.decimal.floatValue(), basik.decimal.floatValue());
@@ -107,7 +106,7 @@ public class MySQLBasicTest extends BaseRxTest {
 							return s2.persist(basic.parent)
 									.thenCompose( v -> s2.flush() )
 									.thenAccept(v -> {
-										context.assertTrue( option.isPresent() );
+										context.assertNotNull( basic );
 										context.assertTrue( basic.postUpdated && basic.preUpdated );
 										context.assertFalse( basic.postPersisted && basic.prePersisted );
 										context.assertTrue( basic.parent.postPersisted && basic.parent.prePersisted );
@@ -117,8 +116,7 @@ public class MySQLBasicTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s3 ->
 					s3.find( Basic.class, basik.getId() )
-						.thenCompose( option -> {
-							Basic basic = option.get();
+						.thenCompose( basic -> {
 							context.assertFalse( basic.postUpdated && basic.preUpdated );
 							context.assertFalse( basic.postPersisted && basic.prePersisted );
 							context.assertEquals( basic.version, 1 );
@@ -131,7 +129,7 @@ public class MySQLBasicTest extends BaseRxTest {
 				.thenCompose(v -> openSession())
 				.thenCompose(s4 ->
 						s4.find( Basic.class, basik.getId() )
-							.thenAccept( option -> context.assertFalse( option.isPresent() ) ))
+							.thenAccept(context::assertNull))
 		);
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/OneToOneIdClassParentEmbeddedIdTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/OneToOneIdClassParentEmbeddedIdTest.java
@@ -31,9 +31,9 @@ public class OneToOneIdClassParentEmbeddedIdTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( s -> s.find( AnEntity.class, new OtherEntityId( 1 ) )
 								.thenAccept( optionalAnEntity -> {
-									context.assertTrue( optionalAnEntity.isPresent() );
-									context.assertEquals( anEntity, optionalAnEntity.get() );
-									context.assertEquals( otherEntity, optionalAnEntity.get().otherEntity );
+									context.assertNotNull( optionalAnEntity );
+									context.assertEquals( anEntity, optionalAnEntity );
+									context.assertEquals( otherEntity, optionalAnEntity.otherEntity );
 								})
 						)
 		);

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/OneToOneIdClassParentIdClassTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/OneToOneIdClassParentIdClassTest.java
@@ -34,9 +34,9 @@ public class OneToOneIdClassParentIdClassTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( s -> s.find( AnEntity.class, new OtherEntityId( 1 ) )
 								.thenAccept( optionalAnEntity -> {
-									context.assertTrue( optionalAnEntity.isPresent() );
-									context.assertEquals( anEntity, optionalAnEntity.get() );
-									context.assertEquals( otherEntity, optionalAnEntity.get().otherEntity );
+									context.assertNotNull( optionalAnEntity );
+									context.assertEquals( anEntity, optionalAnEntity );
+									context.assertEquals( otherEntity, optionalAnEntity.otherEntity );
 								})
 						)
 		);

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/OneToOneNoIdClassTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/OneToOneNoIdClassTest.java
@@ -33,9 +33,9 @@ public class OneToOneNoIdClassTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( s -> s.find( AnEntity.class, 1 )
 								.thenAccept( optionalAnEntity -> {
-									context.assertTrue( optionalAnEntity.isPresent() );
-									context.assertEquals( anEntity, optionalAnEntity.get() );
-									context.assertEquals( otherEntity, optionalAnEntity.get().otherEntity );
+									context.assertNotNull( optionalAnEntity );
+									context.assertEquals( anEntity, optionalAnEntity );
+									context.assertEquals( otherEntity, optionalAnEntity.otherEntity );
 								})
 						)
 		);

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/ReactiveSessionTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/ReactiveSessionTest.java
@@ -9,7 +9,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 public class ReactiveSessionTest extends BaseRxTest {
@@ -115,7 +114,7 @@ public class ReactiveSessionTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( session ->
 							session.find( GuineaPig.class, 5 )
-								.thenCompose( aloi -> session.remove( aloi.get() ) )
+								.thenCompose( aloi -> session.remove( aloi ) )
 								.thenCompose( v -> session.flush() )
 								.thenCompose( v -> selectNameFromId( 5 ) )
 								.thenAccept( ret -> context.assertNull( ret ) ) )
@@ -131,8 +130,8 @@ public class ReactiveSessionTest extends BaseRxTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( session ->
 							session.find( GuineaPig.class, 5 )
-								.thenAccept( o -> {
-									GuineaPig pig = o.orElseThrow( () -> new AssertionError( "Guinea pig not found" ) );
+								.thenAccept( pig -> {
+									context.assertNotNull( pig );
 									// Checking we are actually changing the name
 									context.assertNotEquals( pig.getName(), NEW_NAME );
 									pig.setName( NEW_NAME );
@@ -143,10 +142,10 @@ public class ReactiveSessionTest extends BaseRxTest {
 		);
 	}
 
-	private void assertThatPigsAreEqual(TestContext context, GuineaPig expected, Optional<GuineaPig> actual) {
-		context.assertTrue( actual.isPresent() );
-		context.assertEquals( expected.getId(), actual.get().getId() );
-		context.assertEquals( expected.getName(), actual.get().getName() );
+	private void assertThatPigsAreEqual(TestContext context, GuineaPig expected, GuineaPig actual) {
+		context.assertNotNull( actual );
+		context.assertEquals( expected.getId(), actual.getId() );
+		context.assertEquals( expected.getName(), actual.getName() );
 	}
 
 	@Entity

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/SecondaryTableTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/SecondaryTableTest.java
@@ -32,9 +32,9 @@ public class SecondaryTableTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s2 -> s2.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 							context.assertFalse(book.isForbidden());
 						} )
 		);
@@ -53,9 +53,9 @@ public class SecondaryTableTest extends BaseRxTest {
 						.thenCompose( s -> s.flush() )
 						.thenCompose( s -> s.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 							context.assertTrue(book.isForbidden());
 						} )
 		);
@@ -75,9 +75,9 @@ public class SecondaryTableTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertFalse(book.get().isForbidden());
-							context.assertEquals(book.get().getTitle(), "The Boy, The Mole, The Fox and The Horse");
+							context.assertNotNull(book);
+							context.assertFalse(book.isForbidden());
+							context.assertEquals(book.getTitle(), "The Boy, The Mole, The Fox and The Horse");
 						}));
 	}
 
@@ -94,9 +94,9 @@ public class SecondaryTableTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertTrue(book.get().isForbidden());
-							context.assertEquals(book.get().getTitle(), "Necronomicon");
+							context.assertNotNull(book);
+							context.assertTrue(book.isForbidden());
+							context.assertEquals(book.getTitle(), "Necronomicon");
 						}));
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/SequenceGeneratorTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/SequenceGeneratorTest.java
@@ -29,9 +29,8 @@ public class SequenceGeneratorTest extends BaseRxTest {
 				.thenCompose( v -> openSession())
 				.thenCompose( s2 ->
 					s2.find( SequenceId.class, b.getId() )
-						.thenAccept( bt -> {
-							context.assertTrue( bt.isPresent() );
-							SequenceId bb = bt.get();
+						.thenAccept( bb -> {
+							context.assertNotNull( bb );
 							context.assertEquals( bb.id, 5 );
 							context.assertEquals( bb.string, b.string );
 							context.assertEquals( bb.version, 0 );
@@ -41,14 +40,13 @@ public class SequenceGeneratorTest extends BaseRxTest {
 						.thenCompose(vv -> s2.flush())
 						.thenCompose(vv -> s2.find( SequenceId.class, b.getId() ))
 						.thenAccept( bt -> {
-							context.assertEquals( bt.get().version, 1 );
+							context.assertEquals( bt.version, 1 );
 						}))
 				.thenCompose( v -> openSession())
 				.thenCompose( s3 -> s3.find( SequenceId.class, b.getId() ) )
-				.thenAccept( bt -> {
-					SequenceId bb = bt.get();
+				.thenAccept( bb -> {
 					context.assertEquals(bb.version, 1);
-					context.assertEquals( bb.string, "Goodbye");
+					context.assertEquals(bb.string, "Goodbye");
 				})
 		);
 	}

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/SingleTableInheritanceTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/SingleTableInheritanceTest.java
@@ -57,9 +57,9 @@ public class SingleTableInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s2 -> s2.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle() );
 						} )
 		);
 	}
@@ -77,9 +77,9 @@ public class SingleTableInheritanceTest extends BaseRxTest {
 						.thenCompose( s -> s.flush() )
 						.thenCompose( s -> s.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 						} )
 		);
 	}
@@ -98,9 +98,9 @@ public class SingleTableInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertFalse(book.get() instanceof SpellBook);
-							context.assertEquals(book.get().getTitle(), "The Boy, The Mole, The Fox and The Horse");
+							context.assertNotNull(book);
+							context.assertFalse(book instanceof SpellBook);
+							context.assertEquals(book.getTitle(), "The Boy, The Mole, The Fox and The Horse");
 						}));
 	}
 
@@ -117,9 +117,9 @@ public class SingleTableInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertTrue(book.get() instanceof SpellBook);
-							context.assertEquals(book.get().getTitle(), "Necronomicon");
+							context.assertNotNull(book);
+							context.assertTrue(book instanceof SpellBook);
+							context.assertEquals(book.getTitle(), "Necronomicon");
 						}));
 	}
 

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/TableGeneratorTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/TableGeneratorTest.java
@@ -29,9 +29,8 @@ public class TableGeneratorTest extends BaseRxTest {
 				.thenCompose( v -> openSession())
 				.thenCompose( s2 ->
 					s2.find( TableId.class, b.getId() )
-						.thenAccept( bt -> {
-							context.assertTrue( bt.isPresent() );
-							TableId bb = bt.get();
+						.thenAccept( bb -> {
+							context.assertNotNull( bb );
 							context.assertEquals( bb.id, 6 );
 							context.assertEquals( bb.string, b.string );
 							context.assertEquals( bb.version, 0 );
@@ -41,12 +40,11 @@ public class TableGeneratorTest extends BaseRxTest {
 						.thenCompose(vv -> s2.flush())
 						.thenCompose(vv -> s2.find( TableId.class, b.getId() ))
 						.thenAccept( bt -> {
-							context.assertEquals( bt.get().version, 1 );
+							context.assertEquals( bt.version, 1 );
 						}))
 				.thenCompose( v -> openSession())
 				.thenCompose( s3 -> s3.find( TableId.class, b.getId() ) )
-				.thenAccept( bt -> {
-					TableId bb = bt.get();
+				.thenAccept( bb -> {
 					context.assertEquals(bb.version, 1);
 					context.assertEquals( bb.string, "Goodbye");
 				})

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/UUIDGeneratorTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/UUIDGeneratorTest.java
@@ -33,9 +33,8 @@ public class UUIDGeneratorTest extends BaseRxTest {
 				.thenCompose( v -> openSession())
 				.thenCompose( s2 ->
 					s2.find( TableId.class, b.getId() )
-						.thenAccept( bt -> {
-							context.assertTrue( bt.isPresent() );
-							TableId bb = bt.get();
+						.thenAccept( bb -> {
+							context.assertNotNull( bb );
 							context.assertNotNull( bb.id );
 							context.assertEquals( bb.string, b.string );
 							context.assertEquals( bb.version, 0 );
@@ -45,12 +44,11 @@ public class UUIDGeneratorTest extends BaseRxTest {
 						.thenCompose(vv -> s2.flush())
 						.thenCompose(vv -> s2.find( TableId.class, b.getId() ))
 						.thenAccept( bt -> {
-							context.assertEquals( bt.get().version, 1 );
+							context.assertEquals( bt.version, 1 );
 						}))
 				.thenCompose( v -> openSession())
 				.thenCompose( s3 -> s3.find( TableId.class, b.getId() ) )
-				.thenAccept( bt -> {
-					TableId bb = bt.get();
+				.thenAccept( bb -> {
 					context.assertEquals(bb.version, 1);
 					context.assertEquals( bb.string, "Goodbye");
 				})

--- a/hibernate-rx-core/src/test/java/org/hibernate/rx/UnionSubclassInheritanceTest.java
+++ b/hibernate-rx-core/src/test/java/org/hibernate/rx/UnionSubclassInheritanceTest.java
@@ -33,9 +33,9 @@ public class UnionSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose( s2 -> s2.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 						} )
 		);
 	}
@@ -53,9 +53,9 @@ public class UnionSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( s -> s.flush() )
 						.thenCompose( s -> s.find( Author.class, author.getId() ) )
 						.thenAccept( auth -> {
-							context.assertTrue( auth.isPresent() );
-							context.assertEquals( author, auth.get() );
-							context.assertEquals( book.getTitle(), auth.get().getBook().getTitle()  );
+							context.assertNotNull( auth );
+							context.assertEquals( author, auth );
+							context.assertEquals( book.getTitle(), auth.getBook().getTitle()  );
 						} )
 		);
 	}
@@ -74,9 +74,9 @@ public class UnionSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertFalse(book.get() instanceof SpellBook);
-							context.assertEquals(book.get().getTitle(), "The Boy, The Mole, The Fox and The Horse");
+							context.assertNotNull(book);
+							context.assertFalse(book instanceof SpellBook);
+							context.assertEquals(book.getTitle(), "The Boy, The Mole, The Fox and The Horse");
 						}));
 	}
 
@@ -93,9 +93,9 @@ public class UnionSubclassInheritanceTest extends BaseRxTest {
 						.thenCompose( v -> openSession())
 						.thenCompose(s -> s.find(Book.class, 6))
 						.thenAccept(book -> {
-							context.assertTrue(book.isPresent());
-							context.assertTrue(book.get() instanceof SpellBook);
-							context.assertEquals(book.get().getTitle(), "Necronomicon");
+							context.assertNotNull(book);
+							context.assertTrue(book instanceof SpellBook);
+							context.assertEquals(book.getTitle(), "Necronomicon");
 						}));
 	}
 


### PR DESCRIPTION
As proposed in #52, this change kicks `Optional` out of our code base.

Justification:

- it doesn't really protect you from NPEs because nothing stops you from calling `get()` on an uninitialized one (unlike other langs, Java doesn't have sum or union types) ... even worse, nothing stops you from assigning `null` to the type `Optional`
- indeed, it actually causes more bugs than it avoids, since `Optional` is assignable to `Object`
- it makes you create extra local variables to assign the result of `get()` to (unlike Ceylon, Java doesn't have intersection types)
- its comes with a performance overhead (Java doesn't have value types or union types)
- it makes method signatures uglier (unlike other langs, Java doesn't have a syntax sugar for it)

Does anybody want to step up and defend this 'orrible thing?