### PR TITLE
Add gradle script for publishing as Maven publication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ subprojects {
         jcenter()
         mavenCentral()
     }
+    
+    ext.publishScript = rootProject.rootDir.absolutePath + '/publish.gradle'
 }
 
 // Versions which need to be aligned across modules;

--- a/hibernate-rx-api/build.gradle
+++ b/hibernate-rx-api/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    // Apply the java-library plugin to add support for Java Library
     id 'java-library'
 }
+apply from: publishScript
 
 description = 'Hibernate RX API'
  

--- a/hibernate-rx-api/src/main/java/org/hibernate/rx/RxSession.java
+++ b/hibernate-rx-api/src/main/java/org/hibernate/rx/RxSession.java
@@ -84,7 +84,7 @@ public interface RxSession {
 	/**
 	 * Asynchronously persist the given transient instance, first assigning
 	 * a generated identifier. (Or using the current value of the identifier
-	 * property if the <tt>assigned</tt> generator is used.) This operation
+	 * property if the <code>assigned</code> generator is used.) This operation
 	 * cascades to associated instances if the association is mapped with
 	 * {@code cascade="save-update"}
 	 *
@@ -140,7 +140,7 @@ public interface RxSession {
 	 * <ul>
 	 * <li>where a database trigger alters the object state upon insert or update
 	 * <li>after executing direct SQL (eg. a mass update) in the same session
-	 * <li>after inserting a <tt>Blob</tt> or <tt>Clob</tt>
+	 * <li>after inserting a <code>Blob</code> or <code>Clob</code>
 	 * </ul>
 	 *
 	 * @param entity a persistent or detached instance
@@ -214,7 +214,7 @@ public interface RxSession {
 	 * Remove this instance from the session cache. Changes to the instance
 	 * will not be synchronized with the database. This operation cascades
 	 * to associated instances if the association is mapped with
-	 * <tt>cascade="evict"</tt>.
+	 * <code>cascade="evict"</code>.
 	 *
 	 * @param entity The entity to evict
 	 *
@@ -271,7 +271,7 @@ public interface RxSession {
 
 	/**
 	 * Set the cache mode.
-	 * <p/>
+	 * <p>
 	 * Cache mode determines the manner in which this session can interact with
 	 * the second level cache.
 	 *

--- a/hibernate-rx-core/build.gradle
+++ b/hibernate-rx-core/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    // Apply the java-library plugin to add support for Java Library
     id 'java-library'
 }
+apply from: publishScript
 
 description = 'Hibernate Rx Core'
 
@@ -37,7 +37,6 @@ dependencies {
 
 test {
   defaultCharacterEncoding = "UTF-8"
-  //useJUnitPlatform()
   testLogging {
       displayGranularity 1
       showStandardStreams = false

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxDeleteEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxDeleteEventListener.java
@@ -181,7 +181,7 @@ public class DefaultRxDeleteEventListener
 
 	/**
 	 * Called when we have recognized an attempt to delete a detached entity.
-	 * <p/>
+	 * <p>
 	 * This is perfectly valid in Hibernate usage; JPA, however, forbids this.
 	 * Thus, this is a hook for HEM to affect this behavior.
 	 *
@@ -206,7 +206,7 @@ public class DefaultRxDeleteEventListener
 
 	/**
 	 * We encountered a delete request on a transient instance.
-	 * <p/>
+	 * <p>
 	 * This is a deviation from historical Hibernate (pre-3.2) behavior to
 	 * align with the JPA spec, which states that transient entities can be
 	 * passed to remove operation in which case cascades still need to be

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxFlushEventListener.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/event/impl/DefaultRxFlushEventListener.java
@@ -309,7 +309,7 @@ public class DefaultRxFlushEventListener implements RxFlushEventListener, FlushE
 	}
 
 	/**
-	 * 1. Recreate the collection key -> collection map
+	 * 1. Recreate the collection key to collection map
 	 * 2. rebuild the collection entries
 	 * 3. call Interceptor.postFlush()
 	 */

--- a/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAbstractEntityPersister.java
+++ b/hibernate-rx-core/src/main/java/org/hibernate/rx/persister/entity/impl/RxAbstractEntityPersister.java
@@ -232,7 +232,7 @@ public interface RxAbstractEntityPersister extends RxEntityPersister, OuterJoinL
 
 	/**
 	 * Perform an SQL INSERT, and then retrieve a generated identifier.
-	 * <p/>
+	 * <p>
 	 * This form is used for PostInsertIdentifierGenerator-style ids (IDENTITY,
 	 * select, etc).
 	 */

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,47 @@
+apply plugin: 'maven-publish'
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = 'sources'
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    archiveClassifier = 'javadoc'
+}
+
+publishing {
+    repositories {
+        mavenLocal()
+    }
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = project.name
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            pom {
+                name = project.properties.title
+                description = project.description
+                url = 'https://github.com/hibernate/hibernate-rx'
+                licenses {
+                    license {
+                        name = 'GNU Lesser General Public License, version 2.1'
+                        url = 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:ssh://git@github.com/hibernate/hibernate-rx.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/hibernate/hibernate-rx.git'
+                    url = 'https://github.com/hibernate/hibernate-rx.git'
+                }
+            }
+        }
+    }
+}
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}


### PR DESCRIPTION
Adds the `hibernate-rx-api` and `hibernate-rx-core` modules as publishable modules. This makes it so when you do `./gradlew publish` or `./gradlew publishToMavenLocal` the build will publish the maven artifacts to your local Maven repo.

There is now a common publish script at publish.gradle and any sub-module that wants to publish a maven artifact can do `apply from: publishScript` in their build.gradle file.