### PR TITLE
Set source compatibility to Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,14 @@ plugins {
 }
 
 subprojects {
+    apply plugin: 'java-library'
+
     group = 'org.hibernate.reactive'
     version = '1.0.0-SNAPSHOT'
+
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    compileJava.options.encoding = 'UTF-8'
 
     repositories {
         mavenLocal()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,8 +1,3 @@
-plugins {
-    // Apply the java-library plugin to add support for Java Library
-    id 'java-library'
-}
-
 description = 'Hibernate Rx Example'
 
 dependencies {

--- a/hibernate-rx-api/build.gradle
+++ b/hibernate-rx-api/build.gradle
@@ -1,6 +1,3 @@
-plugins {
-    id 'java-library'
-}
 apply from: publishScript
 
 description = 'Hibernate RX API'

--- a/hibernate-rx-core/build.gradle
+++ b/hibernate-rx-core/build.gradle
@@ -1,6 +1,3 @@
-plugins {
-    id 'java-library'
-}
 apply from: publishScript
 
 description = 'Hibernate Rx Core'


### PR DESCRIPTION
I kept running into issues pulling int HibernateRX into other projects because I would accidentally build RX with Java 11 and the other projects were running with Java 8.

The build files should explicitly state what source/target compat we are aiming for, so that the produced artifacts are more consistent and do not differ based on what JDK is used to build.